### PR TITLE
Fix the last failing test in Python 3

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -226,14 +226,14 @@ def check_slice(f):
 
 def check_array_copy(f):
     # the array is definitely a copy...
-    a = np.array(f['chr3'])
+    a = np.array(f['chr3'], np.dtype('S1'))
     old = f['chr3'][1:5]
     assert (a.shape[0] == 3600)
     a[1:5] = np.array('N', dtype='S1')
     c = f['chr3'][1:5]
     assert c == old
 
-    assert a[1:5].tostring().decode('ascii') == 'NNNN', a[1:5].tostring().decode('ascii')
+    assert a[1:5].tostring().decode() == 'NNNN', a[1:5].tostring().decode()
 
 def check_one_based(f):
     assert f.sequence({'chr': 'chr1', 'start': 2, 'stop': 9})  == 'CTGACTGA'


### PR DESCRIPTION
In my original "support Python 3" pull request, I mentioned a [strange unit test failure](https://github.com/brentp/pyfasta/issues/9#issuecomment-17244403) that I didn't fix at the time. This seemed like a good time to look in to this and fix it. The `pyfasta` code was fine; the test was what was broken. Everything looks great for Python 3 now but I don't have an environment set up to test this on Python 2, so if the tests pass for you I think it's good to go.

Output of `test_all.py`:

```
Ran 102 tests in 1.840s

OK
```
