### PR TITLE
Make numpy an optional requirement

### DIFF
--- a/pyfasta/fasta.py
+++ b/pyfasta/fasta.py
@@ -3,9 +3,8 @@ import string
 import os.path
 from collections import Mapping
 import sys
-import numpy as np
 
-from records import NpyFastaRecord
+from records import np, DefaultRecord
 
 # string.maketrans is bytes.maketrans in Python 3, but
 # we want to deal with strings instead of bytes
@@ -40,7 +39,7 @@ class DuplicateHeaderException(Exception):
         Exception.__init__(self, 'headers must be unique: %s is duplicated' % header)
 
 class Fasta(Mapping):
-    def __init__(self, fasta_name, record_class=NpyFastaRecord,
+    def __init__(self, fasta_name, record_class=DefaultRecord,
                 flatten_inplace=False, key_fn=None):
         """
             >>> from pyfasta import Fasta, FastaRecord

--- a/pyfasta/records.py
+++ b/pyfasta/records.py
@@ -1,9 +1,20 @@
 import cPickle
-import numpy as np
 import sys
 import os
 
-__all__ = ['FastaRecord', 'NpyFastaRecord', 'MemoryRecord']
+try:
+    import numpy as np
+except ImportError as err:
+    class NotAvailable:
+        def __getattr__(self, key):
+            raise err
+        def __nonzero__(self):
+            return False
+        def __bool__(self):
+            return False
+    np = NotAvailable()
+
+__all__ = ['FastaRecord', 'NpyFastaRecord', 'MemoryRecord', 'DefaultRecord']
 
 MAGIC = "@flattened@"
 
@@ -293,3 +304,9 @@ try:
     __all__.append('TCRecord')
 except ImportError:
     pass
+
+if np:
+    DefaultRecord = NpyFastaRecord
+else:
+    DefaultRecord = MemoryRecord
+


### PR DESCRIPTION
I'd like to use pyfasta without needing numpy to be available. This can be useful on servers where extra requirements are a pain to install or configure.